### PR TITLE
Add support for infinite scrolling an element not immediately within infinite-scroller

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+2.0.0
+
+* Introduce `use-element` 
+
 1.0.20
 
 * Re-release due to dodgy publish

--- a/README.md
+++ b/README.md
@@ -45,8 +45,13 @@ ember install @zestia/ember-simple-infinite-scroller
     <td></td>
   </tr>
   <tr>
+    <td>use-element</td>
+    <td>Monitors the scrolling of a specific element, e.g. `use-element=".foo-bar"`. This can be used in conjunction with `tagName=""`</td>
+    <td><code>false</code></td>
+  </tr>
+  <tr>
     <td>use-document</td>
-    <td>Goes off document scroll rather than the element's scroll position</td>
+    <td>Goes off the document scroll position rather than the element's scroll position</td>
     <td><code>false</code></td>
   </tr>
   <tr>

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ ember install @zestia/ember-simple-infinite-scroller
   </tr>
   <tr>
     <td>use-element</td>
-    <td>Monitors the scrolling of a specific element, e.g. `use-element=".foo-bar"`. This can be used in conjunction with `tagName=""`</td>
+    <td>Monitors the scrolling of a specific element, e.g. `use-element=".foo-bar"`.</td>
     <td><code>false</code></td>
   </tr>
   <tr>

--- a/addon/components/infinite-scroller.js
+++ b/addon/components/infinite-scroller.js
@@ -10,9 +10,16 @@ export default Component.extend({
 
   layout,
   classNames: ['infinite-scroller'],
-  classNameBindings: ['isLoading'],
 
   debug: false,
+
+  init() {
+    this._super(...arguments);
+
+    if (this.get('tagName') !== '') {
+      this.set('classNameBindings', ['isLoading']);
+    }
+  },
 
   didInsertElement() {
     this._super(...arguments);
@@ -48,6 +55,8 @@ export default Component.extend({
   _listener() {
     if (this.get('use-document')) {
       return this.get('_infiniteScroller.document');
+    } else if (this.get('use-element')) {
+      return document.querySelector(this.get('use-element'));
     } else {
       return this.get('element');
     }
@@ -56,6 +65,8 @@ export default Component.extend({
   _element() {
     if (this.get('use-document')) {
       return this.get('_infiniteScroller.documentElement');
+    } else if (this.get('use-element')) {
+      return document.querySelector(this.get('use-element'));
     } else {
       return this.get('element');
     }

--- a/addon/components/infinite-scroller.js
+++ b/addon/components/infinite-scroller.js
@@ -10,6 +10,7 @@ export default Component.extend({
 
   layout,
   classNames: ['infinite-scroller'],
+  classNameBindings: ['isLoading'],
 
   debug: false,
 

--- a/addon/components/infinite-scroller.js
+++ b/addon/components/infinite-scroller.js
@@ -13,14 +13,6 @@ export default Component.extend({
 
   debug: false,
 
-  init() {
-    this._super(...arguments);
-
-    if (this.get('tagName') !== '') {
-      this.set('classNameBindings', ['isLoading']);
-    }
-  },
-
   didInsertElement() {
     this._super(...arguments);
     this.set('_scrollHandler', bind(this, '_scroll'));
@@ -56,7 +48,7 @@ export default Component.extend({
     if (this.get('use-document')) {
       return this.get('_infiniteScroller.document');
     } else if (this.get('use-element')) {
-      return document.querySelector(this.get('use-element'));
+      return this.get('element').querySelector(this.get('use-element'));
     } else {
       return this.get('element');
     }
@@ -66,7 +58,7 @@ export default Component.extend({
     if (this.get('use-document')) {
       return this.get('_infiniteScroller.documentElement');
     } else if (this.get('use-element')) {
-      return document.querySelector(this.get('use-element'));
+      return this.get('element').querySelector(this.get('use-element'));
     } else {
       return this.get('element');
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zestia/ember-simple-infinite-scroller",
-  "version": "1.0.20",
+  "version": "2.0.0",
   "description": "Simple infinite scroller component for Ember apps",
   "directories": {
     "doc": "doc",

--- a/tests/dummy/app/controllers/example-4.js
+++ b/tests/dummy/app/controllers/example-4.js
@@ -1,0 +1,4 @@
+import Controller from '@ember/controller';
+import Things from '../mixins/things';
+
+export default Controller.extend(Things);

--- a/tests/dummy/app/router.js
+++ b/tests/dummy/app/router.js
@@ -10,6 +10,7 @@ DummyRouter.map(function() {
   this.route('example-1');
   this.route('example-2');
   this.route('example-3');
+  this.route('example-4');
 });
 
 export default DummyRouter;

--- a/tests/dummy/app/routes/example-4.js
+++ b/tests/dummy/app/routes/example-4.js
@@ -1,0 +1,4 @@
+import Route from '@ember/routing/route';
+
+export default Route.extend({
+});

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -4,7 +4,7 @@
   border: 1px solid red;
 }
 
-.external-element {
+.internal-element {
   margin: 20px;
   padding: 10px;
   border: 1px dashed red;
@@ -23,7 +23,7 @@
 
 .example-1,
 .example-3,
-.external-element {
+.internal-element {
   overflow: auto;
   max-height: 200px;
 }

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -4,6 +4,12 @@
   border: 1px solid red;
 }
 
+.external-element {
+  margin: 20px;
+  padding: 10px;
+  border: 1px dashed red;
+}
+
 .thing {
   border: 1px solid blue;
   height: 20px;
@@ -16,7 +22,8 @@
 }
 
 .example-1,
-.example-3 {
+.example-3,
+.external-element {
   overflow: auto;
   max-height: 200px;
 }

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -5,7 +5,8 @@
 
 {{link-to "Example 1" "example-1"}} |
 {{link-to "Example 2" "example-2"}} |
-{{link-to "Example 3" "example-3"}}
+{{link-to "Example 3" "example-3"}} |
+{{link-to "Example 4" "example-4"}}
 
 <p>
   Load delay:<br>

--- a/tests/dummy/app/templates/example-4.hbs
+++ b/tests/dummy/app/templates/example-4.hbs
@@ -1,13 +1,14 @@
 <p>Action is fired when the bottom of the external div is scrolled to</p>
 
-<div class="external-element">
-  {{#each things as |thing|}}
-    <div class="thing">{{thing.name}}</div>
-  {{/each}}
-</div>
-
-{{infinite-scroller
+{{#infinite-scroller
   class="example-4"
   on-load-more=(action "loadMore")
-  tagName=""
   use-element=".external-element"}}
+  <div class="unscrollable-element">
+    <div class="external-element">
+      {{#each things as |thing|}}
+        <div class="thing">{{thing.name}}</div>
+      {{/each}}
+    </div>
+  </div>
+{{/infinite-scroller}}

--- a/tests/dummy/app/templates/example-4.hbs
+++ b/tests/dummy/app/templates/example-4.hbs
@@ -1,11 +1,11 @@
-<p>Action is fired when the bottom of the external div is scrolled to</p>
+<p>Action is fired when the bottom of the internal div is scrolled to</p>
 
 {{#infinite-scroller
   class="example-4"
   on-load-more=(action "loadMore")
-  use-element=".external-element"}}
+  use-element=".internal-element"}}
   <div class="unscrollable-element">
-    <div class="external-element">
+    <div class="internal-element">
       {{#each things as |thing|}}
         <div class="thing">{{thing.name}}</div>
       {{/each}}

--- a/tests/dummy/app/templates/example-4.hbs
+++ b/tests/dummy/app/templates/example-4.hbs
@@ -1,0 +1,13 @@
+<p>Action is fired when the bottom of the external div is scrolled to</p>
+
+<div class="external-element">
+  {{#each things as |thing|}}
+    <div class="thing">{{thing.name}}</div>
+  {{/each}}
+</div>
+
+{{infinite-scroller
+  class="example-4"
+  on-load-more=(action "loadMore")
+  tagName=""
+  use-element=".external-element"}}

--- a/tests/integration/components/infinite-scroller-test.js
+++ b/tests/integration/components/infinite-scroller-test.js
@@ -327,11 +327,11 @@ module('infinite-scroller', function(hooks) {
 
     await render(hbs`
     {{#infinite-scroller
-      use-element=".external-element"
+      use-element=".internal-element"
       on-load-more=(action loadMore)}}
 
       <div class = "non-scrollable-element">
-        <div class="external-element">
+        <div class="internal-element">
           {{#each things as |thing|}}
             <div class="thing">{{thing.name}}</div>
           {{/each}}
@@ -341,7 +341,7 @@ module('infinite-scroller', function(hooks) {
       {{/infinite-scroller}}
     `);
 
-    find('.external-element').scrollTop = 450;
+    find('.internal-element').scrollTop = 450;
 
     await waitUntil(() => findAll('.thing').length === 40);
 

--- a/tests/integration/components/infinite-scroller-test.js
+++ b/tests/integration/components/infinite-scroller-test.js
@@ -323,23 +323,23 @@ module('infinite-scroller', function(hooks) {
   });
 
   test('custom element', async function(assert) {
-    assert.expect(2);
+    assert.expect(1);
 
     await render(hbs`
-      <div class="external-element">
-        {{#each things as |thing|}}
-          <div class="thing">{{thing.name}}</div>
-        {{/each}}
+    {{#infinite-scroller
+      use-element=".external-element"
+      on-load-more=(action loadMore)}}
+
+      <div class = "non-scrollable-element">
+        <div class="external-element">
+          {{#each things as |thing|}}
+            <div class="thing">{{thing.name}}</div>
+          {{/each}}
+        </div>
       </div>
 
-      {{infinite-scroller
-        tagName=""
-        use-element=".external-element"
-        on-load-more=(action loadMore)}}
+      {{/infinite-scroller}}
     `);
-
-    assert.ok(!find('.infinite-scroller'),
-      'can render a tagless component when use-element is specified');
 
     find('.external-element').scrollTop = 450;
 

--- a/tests/integration/components/infinite-scroller-test.js
+++ b/tests/integration/components/infinite-scroller-test.js
@@ -321,4 +321,31 @@ module('infinite-scroller', function(hooks) {
       this.set('show', false);
     }, 25);
   });
+
+  test('custom element', async function(assert) {
+    assert.expect(2);
+
+    await render(hbs`
+      <div class="external-element">
+        {{#each things as |thing|}}
+          <div class="thing">{{thing.name}}</div>
+        {{/each}}
+      </div>
+
+      {{infinite-scroller
+        tagName=""
+        use-element=".external-element"
+        on-load-more=(action loadMore)}}
+    `);
+
+    assert.ok(!find('.infinite-scroller'),
+      'can render a tagless component when use-element is specified');
+
+    find('.external-element').scrollTop = 450;
+
+    await waitUntil(() => findAll('.thing').length === 40);
+
+    assert.ok(true,
+      'fires load more action at the custom element scroll boundary');
+  });
 });


### PR DESCRIPTION
Add a `use-element` input which takes a selector of an element within the infinite scroller that you wish to have support for infinite scroll.